### PR TITLE
#2 disable default keybindings by user-config.

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,3 +6,8 @@ More information can be found [here](https://github.com/mpickering/apply-refact)
 
 * `to` - Apply one hint at cursor position
 * `ta` - Apply all suggestions in the file
+
+If you don't need it, add to .vimrc.
+
+    let g:hlintRefactor#disableDefaultKeybindings = 1
+

--- a/plugin/hlint-refactor.vim
+++ b/plugin/hlint-refactor.vim
@@ -18,6 +18,12 @@ function! ApplyAllSuggestions()
   call cursor(l, c)
 endfunction
 
+ 
+if ( ! exists('g:hlintRefactor#disableDefaultKeybindings') || 
+   \ ! g:hlintRefactor#disableDefaultKeybindings )
 
-map <silent> to :call ApplyOneSuggestion()<CR>
-map <silent> ta :call ApplyAllSuggestions()<CR>
+  map <silent> to :call ApplyOneSuggestion()<CR>
+  map <silent> ta :call ApplyAllSuggestions()<CR>
+
+endif
+


### PR DESCRIPTION
This patch fixes overlaping of default keybindings by disabling that, and add instruction to README.

If you apply this patch, your plugin will map 'to' and 'ta' only when the vim variable 'g:hlintRefactor#disableDefaultKeybindings' is set falsy.
